### PR TITLE
chore: rewrite all custom botpress code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Nodejs binding for fasttext representation and classification.
 
 > This is a link to the Facebook [fastText](https://github.com/facebookresearch/fastText). A Library for efficient text classification and representation learning.
 
-* FASTTEXT_VERSION = 12;
-* FASTTEXT_FILEFORMAT_MAGIC_INT32 = 793712314;
+- FASTTEXT_VERSION = 12;
+- FASTTEXT_FILEFORMAT_MAGIC_INT32 = 793712314;
 
 # Installation
 
@@ -24,49 +24,47 @@ Using npm:
 According to [fasttext.cc](https://fasttext.cc/docs/en/supervised-tutorial.html). We have a simple classifier for executing prediction models about `cooking` from stackexchange questions:
 
 ```js
-const path = require('path');
-const fastText = require('fasttext');
+const path = require('path')
+const fastText = require('fasttext')
 
-const model = path.resolve(__dirname, './model_cooking.bin');
-const classifier = new fastText.Classifier(model);
+const model = path.resolve(__dirname, './model_cooking.bin')
+const classifier = new fastText.Classifier(model)
 
-classifier.predict('Why not put knives in the dishwasher?', 5)
-    .then((res) => {
-        if (res.length > 0) {
-            let tag = res[0].label; // __label__knives
-            let confidence = res[0].value // 0.8787146210670471
-            console.log('classify', tag, confidence, res);
-        } else {
-            console.log('No matches');
-        }
-    });
+classifier.predict('Why not put knives in the dishwasher?', 5).then(res => {
+  if (res.length > 0) {
+    let tag = res[0].label // __label__knives
+    let confidence = res[0].value // 0.8787146210670471
+    console.log('classify', tag, confidence, res)
+  } else {
+    console.log('No matches')
+  }
+})
 ```
 
 The model haved trained before with the followings params:
 
 ```js
-const path = require('path');
-const fastText = require('fasttext');
+const path = require('path')
+const fastText = require('fasttext')
 
-let data = path.resolve(path.join(__dirname, '../data/cooking.train.txt'));
-let model = path.resolve(path.join(__dirname, '../data/cooking.model'));
+let data = path.resolve(path.join(__dirname, '../data/cooking.train.txt'))
+let model = path.resolve(path.join(__dirname, '../data/cooking.model'))
 
-let classifier = new fastText.Classifier();
+let classifier = new fastText.Classifier()
 let options = {
-    input: data,
-    output: model,
-    loss: "softmax",
-    dim: 200,
-    bucket: 2000000
+  input: data,
+  output: model,
+  loss: 'softmax',
+  dim: 200,
+  bucket: 2000000
 }
 
-classifier.train('supervised', options)
-    .then((res) => {
-        console.log('model info after training:', res)
-        // Input  <<<<< C:\projects\node-fasttext\test\data\cooking.train.txt
-        // Output >>>>> C:\projects\node-fasttext\test\data\cooking.model.bin
-        // Output >>>>> C:\projects\node-fasttext\test\data\cooking.model.vec
-    });
+classifier.train('supervised', options).then(res => {
+  console.log('model info after training:', res)
+  // Input  <<<<< C:\projects\node-fasttext\test\data\cooking.train.txt
+  // Output >>>>> C:\projects\node-fasttext\test\data\cooking.model.bin
+  // Output >>>>> C:\projects\node-fasttext\test\data\cooking.model.vec
+})
 ```
 
 Or you can train directly from the command line with fasttext builded from official source:
@@ -92,28 +90,32 @@ Number of examples: 3000
 Simple class for searching nearest neighbors:
 
 ```js
-const path = require('path');
-const fastText = require('fasttext');
+const path = require('path')
+const fastText = require('fasttext')
 
-const model = path.resolve(__dirname, './skipgram.bin');
-const query = new fastText.Query(model);
+const model = path.resolve(__dirname, './skipgram.bin')
+const query = new fastText.Query(model)
 
 query.nn('word', 5, (err, res) => {
-    if (err) {
-        console.error(err);
-    } else if (res.length > 0) {
-        let tag = res[0].label; // letter
-        let confidence = res[0].value // 0.99992
-        console.log('Nearest neighbor', tag, confidence, res);
-    } else {
-        console.log('No matches');
-    }
-});
+  if (err) {
+    console.error(err)
+  } else if (res.length > 0) {
+    let tag = res[0].label // letter
+    let confidence = res[0].value // 0.99992
+    console.log('Nearest neighbor', tag, confidence, res)
+  } else {
+    console.log('No matches')
+  }
+})
 ```
 
 # Build from source
 
 See [Installation Prerequisites](https://github.com/nodejs/node-gyp#installation).
+
+Make sure you checked-out fastText submodule: `git submodule update --init`
+
+> If you're building for Linux, run `./linux-build.sh` before
 
 ```bash
 # install dependencies and tools

--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,9 @@
                 "src/wrapper.cc",
                 "src/classifier.cc",
                 "src/query.cc",
-                "src/addon.cc"
+                "src/addon.cc",
+                "src/utils.cc",
+                "src/vecWorker.cc"
             ],
             "defines": [
                 "NAPI_VERSION=<(napi_build_version)",

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,111 +1,111 @@
 {
-  "targets": [
-    {
-      "target_name": "fasttext",
-      "sources": [
-        "fastText/src/args.h",
-        "fastText/src/args.cc",
-        "fastText/src/dictionary.h",
-        "fastText/src/dictionary.cc",
-        "fastText/src/fasttext.h",
-        "fastText/src/fasttext.cc",
-        "fastText/src/matrix.h",
-        "fastText/src/matrix.cc",
-        "fastText/src/model.h",
-        "fastText/src/model.cc",
-        "fastText/src/productquantizer.h",
-        "fastText/src/productquantizer.cc",
-        "fastText/src/qmatrix.h",
-        "fastText/src/qmatrix.cc",
-        "fastText/src/real.h",
-        "fastText/src/utils.h",
-        "fastText/src/utils.cc",
-        "fastText/src/vector.h",
-        "fastText/src/vector.cc",
-        "src/node-util.cc",
-        "src/node-argument.cc",
-        "src/loadModel.cc",
-        "src/train.cc",
-        "src/quantize.cc",
-        "src/predictWorker.cc",
-        "src/nnWorker.cc",
-        "src/wrapper.cc",
-        "src/classifier.cc",
-        "src/query.cc",
-        "src/addon.cc"
-      ],
-      "defines": [
-        "NAPI_VERSION=<(napi_build_version)",
-      ],
-      "include_dirs": [
-        "<!@(node -p \"require('node-addon-api').include\")"
-      ],
-      "cflags": [
-          "-std=c++11",
-          "-pthread",
-          "-fexceptions",
-          "-O3",
-          "-Wall",
-          "-Wno-sign-compare",
-          "-pedantic",
-          "-DUSE_SSE",
-          "-DUSE_SSE2"
-      ],
-      "conditions": [
-          [ "OS=='linux'", {
-              "cflags+": [ "-std=c++11", "-fexceptions" ],
-              "cflags_c+": [ "-std=c++11", "-fexceptions" ],
-              "cflags_cc+": [ "-std=c++11", "-fexceptions" ],
-          }],
-          [ "OS=='freebsd'", {
-              "cflags+": [ "-std=c++11", "-fexceptions" ],
-              "cflags_c+": [ "-std=c++11", "-fexceptions" ],
-              "cflags_cc+": [ "-std=c++11", "-fexceptions" ],
-          }],
-          [ "OS=='mac'", {
-              "cflags+": [ "-stdlib=libc++" ],
-              "xcode_settings": {
-                  "OTHER_CPLUSPLUSFLAGS" : [ "-std=c++11", "-stdlib=libc++", "-pthread" ],
-                  "OTHER_LDFLAGS": [ "-stdlib=libc++" ],
-                  "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-                  "MACOSX_DEPLOYMENT_TARGET": "10.7",
-                  "CLANG_CXX_LANGUAGE_STANDARD":"c++11",
-                  "CLANG_CXX_LIBRARY": "libc++"
-              },
-          }],
-          [
-          "OS=='win'", {
-            "cflags": [
-              "-Wall"
+    "targets": [
+        {
+            "target_name": "fasttext",
+            "sources": [
+                "fastText/src/args.h",
+                "fastText/src/args.cc",
+                "fastText/src/dictionary.h",
+                "fastText/src/dictionary.cc",
+                "fastText/src/fasttext.h",
+                "fastText/src/fasttext.cc",
+                "fastText/src/matrix.h",
+                "fastText/src/matrix.cc",
+                "fastText/src/model.h",
+                "fastText/src/model.cc",
+                "fastText/src/productquantizer.h",
+                "fastText/src/productquantizer.cc",
+                "fastText/src/qmatrix.h",
+                "fastText/src/qmatrix.cc",
+                "fastText/src/real.h",
+                "fastText/src/utils.h",
+                "fastText/src/utils.cc",
+                "fastText/src/vector.h",
+                "fastText/src/vector.cc",
+                "src/node-util.cc",
+                "src/node-argument.cc",
+                "src/loadModel.cc",
+                "src/train.cc",
+                "src/quantize.cc",
+                "src/predictWorker.cc",
+                "src/nnWorker.cc",
+                "src/wrapper.cc",
+                "src/classifier.cc",
+                "src/query.cc",
+                "src/addon.cc"
             ],
             "defines": [
-              "WIN"
+                "NAPI_VERSION=<(napi_build_version)",
             ],
-            "msvs_settings": {
-              "VCCLCompilerTool": {
-                "ExceptionHandling": "2",
-                "DisableSpecificWarnings": [
-                  "4244"
-                ],
-              },
-              "VCLinkerTool": {
-                "LinkTimeCodeGeneration": 1,
-                "OptimizeReferences": 2,
-                "EnableCOMDATFolding": 2,
-                "LinkIncremental": 1,
-              }
-            }
-          }]
-      ]
-    },
-    {
-      "target_name": "action_after_build",
-      "type": "none",
-      "dependencies": ["<(module_name)"],
-      "copies": [{
-          "files": ["<(PRODUCT_DIR)/<(module_name).node"],
-          "destination": "<(module_path)"
-      }]
-    }
-  ]
+            "include_dirs": [
+                "<!@(node -p \"require('node-addon-api').include\")"
+            ],
+            "cflags": [
+                "-std=c++11",
+                "-pthread",
+                "-fexceptions",
+                "-O3",
+                "-Wall",
+                "-Wno-sign-compare",
+                "-pedantic",
+                "-DUSE_SSE",
+                "-DUSE_SSE2"
+            ],
+            "conditions": [
+                ["OS=='linux'", {
+                    "cflags+": ["-std=c++11", "-fexceptions"],
+                    "cflags_c+": ["-std=c++11", "-fexceptions"],
+                    "cflags_cc+": ["-std=c++11", "-fexceptions"],
+                }],
+                ["OS=='freebsd'", {
+                    "cflags+": ["-std=c++11", "-fexceptions"],
+                    "cflags_c+": ["-std=c++11", "-fexceptions"],
+                    "cflags_cc+": ["-std=c++11", "-fexceptions"],
+                }],
+                ["OS=='mac'", {
+                    "cflags+": ["-stdlib=libc++"],
+                    "xcode_settings": {
+                        "OTHER_CPLUSPLUSFLAGS": ["-std=c++11", "-stdlib=libc++", "-pthread"],
+                        "OTHER_LDFLAGS": ["-stdlib=libc++"],
+                        "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+                        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+                        "CLANG_CXX_LANGUAGE_STANDARD":"c++11",
+                        "CLANG_CXX_LIBRARY": "libc++"
+                    },
+                }],
+                [
+                    "OS=='win'", {
+                        "cflags": [
+                            "-Wall"
+                        ],
+                        "defines": [
+                            "WIN"
+                        ],
+                        "msvs_settings": {
+                            "VCCLCompilerTool": {
+                                "ExceptionHandling": "2",
+                                "DisableSpecificWarnings": [
+                                    "4244"
+                                ],
+                            },
+                            "VCLinkerTool": {
+                                "LinkTimeCodeGeneration": 1,
+                                "OptimizeReferences": 2,
+                                "EnableCOMDATFolding": 2,
+                                "LinkIncremental": 1,
+                            }
+                        }
+                    }]
+            ]
+        },
+        {
+            "target_name": "action_after_build",
+            "type": "none",
+            "dependencies": ["<(module_name)"],
+            "copies": [{
+                "files": ["<(PRODUCT_DIR)/<(module_name).node"],
+                "destination": "<(module_path)"
+            }]
+        }
+    ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,8 @@
                 "fastText/src/matrix.cc",
                 "fastText/src/model.h",
                 "fastText/src/model.cc",
+                "fastText/src/meter.h",
+                "fastText/src/meter.cc",
                 "fastText/src/productquantizer.h",
                 "fastText/src/productquantizer.cc",
                 "fastText/src/qmatrix.h",

--- a/src/loadModel.cc
+++ b/src/loadModel.cc
@@ -7,6 +7,11 @@ void LoadModelWorker::Execute()
   {
     result_ = wrapper_->loadModel(filename);
   }
+  catch (const char *str)
+  {
+    std::cout << "Exception: " << str << std::endl;
+    SetError(str);
+  }
   catch (std::string errorMessage)
   {
     SetError(errorMessage.c_str());

--- a/src/query.h
+++ b/src/query.h
@@ -4,7 +4,9 @@
 #include <napi.h>
 #include "wrapper.h"
 #include "nnWorker.h"
+#include "vecWorker.h"
 #include "node-util.h"
+#include "utils.h"
 
 class FasttextQuery : public Napi::ObjectWrap<FasttextQuery>
 {
@@ -23,6 +25,7 @@ public:
 private:
   static Napi::FunctionReference constructor;
   Napi::Value Nn(const Napi::CallbackInfo &info);
+  Napi::Value getWordVector(const Napi::CallbackInfo &info);
 
   Wrapper *wrapper_;
 };

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,0 +1,18 @@
+#include "utils.h"
+
+Napi::Array napi_utils::arrayToNapi(Napi::Env env, std::vector<double> array, unsigned int array_size)
+{
+  Napi::Array napiArray = Napi::Array::New(env);
+
+  if (array.size() == 0)
+  {
+    return napiArray;
+  }
+
+  for (unsigned int i = 0; i < array_size; i++)
+  {
+    napiArray.Set(i, array[i]);
+  }
+
+  return napiArray;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,9 @@
+#include <napi.h>
+#include <iostream>
+#include <vector>
+#include <string>
+
+namespace napi_utils
+{
+  Napi::Array arrayToNapi(Napi::Env env, std::vector<double> array, unsigned int array_size);
+}

--- a/src/vecWorker.cc
+++ b/src/vecWorker.cc
@@ -1,0 +1,58 @@
+#include "vecWorker.h"
+#include "node-util.h"
+
+VecWorker::VecWorker(std::string query,
+                     Wrapper *wrapper,
+                     Napi::Promise::Deferred deferred,
+                     Napi::Function &callback) : AsyncWorker(callback), deferred_(deferred)
+{
+  this->query_ = query;
+  this->wrapper_ = wrapper;
+}
+
+void VecWorker::Execute()
+{
+  try
+  {
+    wrapper_->loadModel();
+    wrapper_->precomputeWordVectors();
+    result_ = this->wrapper_->getWordVector(query_);
+  }
+  catch (std::string errorMessage)
+  {
+    SetError(errorMessage.c_str());
+  }
+  catch (const char *str)
+  {
+    SetError(str);
+  }
+  catch (const std::exception &e)
+  {
+    SetError(e.what());
+  }
+}
+
+void VecWorker::OnError(const Napi::Error &e)
+{
+  Napi::HandleScope scope(Env());
+  Napi::String error = Napi::String::New(Env(), e.Message());
+  deferred_.Reject(error);
+
+  // Call empty function
+  Callback().Call({error});
+}
+
+void VecWorker::OnOK()
+{
+  Napi::Env env = Env();
+  Napi::HandleScope scope(env);
+  Napi::Number result = Napi::Number::New(env, 69);
+
+  deferred_.Resolve(result);
+
+  // Call empty function
+  if (!Callback().IsEmpty())
+  {
+    Callback().Call({env.Null(), result});
+  }
+}

--- a/src/vecWorker.cc
+++ b/src/vecWorker.cc
@@ -46,7 +46,7 @@ void VecWorker::OnOK()
 {
   Napi::Env env = Env();
   Napi::HandleScope scope(env);
-  Napi::Number result = Napi::Number::New(env, 69);
+  Napi::Array result = napi_utils::arrayToNapi(env, result_, result_.size());
 
   deferred_.Resolve(result);
 

--- a/src/vecWorker.h
+++ b/src/vecWorker.h
@@ -4,6 +4,7 @@
 
 #include <napi.h>
 #include "wrapper.h"
+#include "utils.h"
 
 class VecWorker : public Napi::AsyncWorker
 {

--- a/src/vecWorker.h
+++ b/src/vecWorker.h
@@ -1,0 +1,29 @@
+
+#ifndef VEC_WORKER_H
+#define VEC_WORKER_H
+
+#include <napi.h>
+#include "wrapper.h"
+
+class VecWorker : public Napi::AsyncWorker
+{
+public:
+  VecWorker(
+      std::string query,
+      Wrapper *wrapper,
+      Napi::Promise::Deferred deferred,
+      Napi::Function &callback);
+
+  Napi::Promise::Deferred deferred_;
+
+  void Execute();
+  void OnOK();
+  void OnError(const Napi::Error &e);
+
+private:
+  std::string query_;
+  Wrapper *wrapper_;
+  std::vector<double> result_;
+};
+
+#endif

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -242,15 +242,15 @@ void Wrapper::precomputeWordVectors()
     return;
   }
   Matrix wordVectors(dict_->nwords(), args_->dim);
-  wordVectors_ = wordVectors;
+  // wordVectors_ = Matrix(dict_->nwords(), args_->dim);
   Vector vec(args_->dim);
-  wordVectors_.zero();
+  // wordVectors_.zero();
   for (int32_t i = 0; i < dict_->nwords(); i++)
   {
     std::string word = dict_->getWord(i);
     getVector(vec, word);
     real norm = vec.norm();
-    wordVectors_.addRow(vec, i, 1.0 / norm);
+    // wordVectors_.addRow(vec, i, 1.0 / norm);
   }
   isPrecomputed_ = true;
   precomputeMtx_.unlock();
@@ -325,7 +325,7 @@ std::vector<PredictResult> Wrapper::predict(std::string sentence, int32_t k)
   std::vector<int32_t> words, labels;
   std::istringstream in(sentence);
 
-  dict_->getLine(in, words, labels, model_->rng);
+  dict_->getLine(in, words, labels);
 
   // std::cerr << "Got line!" << std::endl;
 
@@ -337,7 +337,7 @@ std::vector<PredictResult> Wrapper::predict(std::string sentence, int32_t k)
   Vector hidden(args_->dim);
   Vector output(dict_->nlabels());
   std::vector<std::pair<real, int32_t>> modelPredictions;
-  model_->predict(words, k, modelPredictions, hidden, output);
+  model_->predict(words, k, 0.0001, modelPredictions, hidden, output);
 
   PredictResult response;
 
@@ -352,47 +352,47 @@ std::vector<PredictResult> Wrapper::predict(std::string sentence, int32_t k)
 
 std::map<std::string, std::string> Wrapper::train(const std::vector<std::string> args)
 {
-  std::shared_ptr<Args> a = std::make_shared<Args>();
-  a->parseArgs(args);
+  Args a;
+  a.parseArgs(args);
 
-  std::string inputFilename = a->input;
+  std::string inputFilename = a.input;
   if (!fileExist(inputFilename))
   {
     throw "Input file is not exist.";
   }
 
-  if (a->verbose > 0)
+  if (a.verbose > 0)
   {
-    std::cout << "Input  <<<<< " << a->input << std::endl;
-    std::cout << "Output >>>>> " << a->output + ".bin" << std::endl;
+    std::cout << "Input  <<<<< " << a.input << std::endl;
+    std::cout << "Output >>>>> " << a.output + ".bin" << std::endl;
   }
 
   fastText_.train(a);
   fastText_.saveModel();
   fastText_.saveVectors();
-  return loadModel(a->output + ".bin");
+  return loadModel(a.output + ".bin");
 }
 
 std::map<std::string, std::string> Wrapper::quantize(const std::vector<std::string> args)
 {
-  std::shared_ptr<Args> a = std::make_shared<Args>();
-  a->parseArgs(args);
+  Args a;
+  a.parseArgs(args);
 
-  if (!fileExist(a->input))
+  if (!fileExist(a.input))
   {
     throw "Input file is not exist.";
   }
 
-  if (a->verbose > 0)
+  if (a.verbose > 0)
   {
-    std::cout << "Input: " << a->input << std::endl;
-    std::cout << "Model: " << a->output + ".bin" << std::endl;
-    std::cout << "Quantized: " << a->output + ".ftz" << std::endl;
+    std::cout << "Input: " << a.input << std::endl;
+    std::cout << "Model: " << a.output + ".bin" << std::endl;
+    std::cout << "Quantized: " << a.output + ".ftz" << std::endl;
   }
 
-  // parseArgs checks if a->output is given.
-  fastText_.loadModel(a->output + ".bin");
+  // parseArgs checks if a.output is given.
+  fastText_.loadModel(a.output + ".bin");
   fastText_.quantize(a);
   fastText_.saveModel();
-  return loadModel(a->output + ".ftz");
+  return loadModel(a.output + ".ftz");
 }

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -361,8 +361,11 @@ std::map<std::string, std::string> Wrapper::train(const std::vector<std::string>
     throw "Input file is not exist.";
   }
 
-  std::cout << "Input  <<<<< " << a->input << std::endl;
-  std::cout << "Output >>>>> " << a->output + ".bin" << std::endl;
+  if (a->verbose > 0)
+  {
+    std::cout << "Input  <<<<< " << a->input << std::endl;
+    std::cout << "Output >>>>> " << a->output + ".bin" << std::endl;
+  }
 
   fastText_.train(a);
   fastText_.saveModel();
@@ -380,9 +383,12 @@ std::map<std::string, std::string> Wrapper::quantize(const std::vector<std::stri
     throw "Input file is not exist.";
   }
 
-  std::cout << "Input: " << a->input << std::endl;
-  std::cout << "Model: " << a->output + ".bin" << std::endl;
-  std::cout << "Quantized: " << a->output + ".ftz" << std::endl;
+  if (a->verbose > 0)
+  {
+    std::cout << "Input: " << a->input << std::endl;
+    std::cout << "Model: " << a->output + ".bin" << std::endl;
+    std::cout << "Quantized: " << a->output + ".ftz" << std::endl;
+  }
 
   // parseArgs checks if a->output is given.
   fastText_.loadModel(a->output + ".bin");

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -301,6 +301,24 @@ std::vector<PredictResult> Wrapper::nn(std::string query, int32_t k)
   return findNN(queryVec, k, banSet);
 }
 
+std::vector<double> Wrapper::getWordVector(std::string query)
+{
+  std::cout << args_->dim << std::endl;
+  Vector queryVec(args_->dim);
+  std::set<std::string> banSet;
+  banSet.clear();
+  banSet.insert(query);
+  getVector(queryVec, query);
+  std::vector<double> ret;
+
+  for (int64_t it = 0; it != args_->dim; it++)
+  {
+    ret.push_back(queryVec[it]);
+  }
+
+  return ret;
+}
+
 std::vector<PredictResult> Wrapper::predict(std::string sentence, int32_t k)
 {
 

--- a/src/wrapper.cc
+++ b/src/wrapper.cc
@@ -303,7 +303,6 @@ std::vector<PredictResult> Wrapper::nn(std::string query, int32_t k)
 
 std::vector<double> Wrapper::getWordVector(std::string query)
 {
-  std::cout << args_->dim << std::endl;
   Vector queryVec(args_->dim);
   std::set<std::string> banSet;
   banSet.clear();

--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -74,6 +74,7 @@ public:
 
   std::vector<PredictResult> predict(std::string sentence, int32_t k);
   std::vector<PredictResult> nn(std::string query, int32_t k);
+  std::vector<double> getWordVector(std::string query);
   std::map<std::string, std::string> train(const std::vector<std::string> args);
   std::map<std::string, std::string> quantize(const std::vector<std::string> args);
 

--- a/tape.js
+++ b/tape.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+var resolveModule = require('resolve').sync;
+var resolvePath = require('path').resolve;
+var parseOpts = require('minimist');
+var glob = require('glob');
+
+var opts = parseOpts(process.argv.slice(2), {
+        alias: { r: 'require' },
+        string: 'require',
+        default: { r: [] }
+    });
+
+var cwd = process.cwd();
+
+if (typeof opts.require === 'string') {
+    opts.require = [opts.require];
+}
+
+opts.require.forEach(function(module) {
+    if (module) {
+        /* This check ensures we ignore `-r ""`, trailing `-r`, or
+         * other silly things the user might (inadvertently) be doing.
+         */
+        require(resolveModule(module, { basedir: cwd }));
+    }
+});
+
+opts._.forEach(function (arg) {
+    // If glob does not match, `files` will be an empty array.
+    // Note: `glob.sync` may throw an error and crash the node process.
+    var files = glob.sync(arg);
+
+    if (!Array.isArray(files)) {
+        throw new TypeError('unknown error: glob.sync did not return an array or throw. Please report this.');
+    }
+
+    files.forEach(function (file) {
+        require(resolvePath(cwd, file));
+    });
+});
+
+// vim: ft=javascript

--- a/test/specs/fastText.js
+++ b/test/specs/fastText.js
@@ -1,27 +1,28 @@
-'use strict';
-const test = require('tape');
-const path = require('path');
-const fastText = require('../../index');
+'use strict'
+const test = require('tape')
+const path = require('path')
+const fastText = require('../../index.js')
 
-test('fastText classifier', function (t) {
-    t.plan(3)
+test('fastText classifier', function(t) {
+  t.plan(3)
 
-    let model_path = path.resolve(path.join(__dirname, '../models/model_cooking.bin'))
-    console.log('File model path: ' + model_path)
-    let classifier = new fastText.Classifier();
+  let model_path = path.resolve(path.join(__dirname, '../models/model_cooking.bin'))
+  console.log('File model path: ' + model_path)
+  let classifier = new fastText.Classifier()
 
-    classifier.loadModel(model_path)
-        .then((info) => {
-            console.log('load model success!!!', info);
-            t.equal(info.model, 'supervised', 'load supervised model');
-            return classifier.predict('Why not put knives in the dishwasher?', 5, 1);
-        })
-        .then((res) => {
-            t.equal(res.length, 5, 'number of classifications output')
-            t.equal(res[0].label, '__label__knives', 'output is __label__knives');
-        })
-        .catch((err) => {
-            console.log('Result: ', err);
-            t.fail(err);
-        })
+  classifier
+    .loadModel(model_path)
+    .then(info => {
+      console.log('load model success!!!', info)
+      t.equal(info.model, 'supervised', 'load supervised model')
+      return classifier.predict('Why not put knives in the dishwasher?', 5, 1)
+    })
+    .then(res => {
+      t.equal(res.length, 5, 'number of classifications output')
+      t.equal(res[0].label, '__label__knives', 'output is __label__knives')
+    })
+    .catch(err => {
+      console.log('Result: ', err)
+      t.fail(err)
+    })
 })

--- a/test/specs/langid.js
+++ b/test/specs/langid.js
@@ -1,7 +1,7 @@
-'use strict';
-const test = require('tape');
-const path = require('path');
-const fastText = require('../../index');
+'use strict'
+const test = require('tape')
+const path = require('path')
+const fastText = require('../../index.js')
 
 test('fastText language identification', function (t) {
   t.plan(3)

--- a/test/specs/trainer.js
+++ b/test/specs/trainer.js
@@ -1,7 +1,7 @@
-'use strict';
-const test = require('tape');
-const path = require('path');
-const fastText = require('../../index');
+'use strict'
+const test = require('tape')
+const path = require('path')
+const fastText = require('../../index')
 
 test('fastText trainer', function (t) {
   t.plan(1)


### PR DESCRIPTION
In this PR I rewrote all the code custom code we needed to make the binding work in botpress.

The binding built on this branch works in botpress and can build with node v12.

**Done**
- added interface for query getWordVectors
- better error handling on loadModel
- cout only when verbose
- updated to the same version of fasttext than the one we already had (not master though)
- added missing classes

basically rewritting all important stuff of these commits:

![image](https://user-images.githubusercontent.com/25970722/83178107-17317800-a0ee-11ea-8d39-fdeb64c53bf1.png)

No need for:

- the memory leak patch as the base repo already patched it
- the 'fix for linux build' script as it already builds on linux

**To do**

I personnally would not add anything in this branch because it already builds and run in botpress, but once this is merged, in another branch, we should update the fasttext version to the most recent one.